### PR TITLE
handle with fizz buzz problem

### DIFF
--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -101,6 +101,32 @@ var builtins = map[string]*object.Builtin{
 			return &object.Integer{Value: result}
 		},
 	},
+	"%": {
+		Fn: func(args object.Object) object.Object {
+			arrayArg, ok := args.(*object.Array)
+			if !ok {
+				return newError("argument to `%%` must be ARRAY, got %s", args.Type())
+			}
+			if len(arrayArg.Elements) != 2 {
+				return newError("number of arguments to '%%' must be 2, got %d", len(arrayArg.Elements))
+			}
+
+			first, ok := arrayArg.Elements[0].(*object.Integer)
+			if !ok {
+				return newError("first argument to '%%' must be INTEGER, got %s", arrayArg.Elements[0].Type())
+			}
+			second, ok := arrayArg.Elements[1].(*object.Integer)
+			if !ok {
+				return newError("second argument to '%%' must be INTEGER, got %s", arrayArg.Elements[1].Type())
+			}
+
+			if second.Value == 0 {
+				return newError("division by zero")
+			}
+
+			return &object.Integer{Value: first.Value % second.Value}
+		},
+	},
 	"==": {
 		Fn: func(args object.Object) object.Object {
 			arrayArg, ok := args.(*object.Array)
@@ -218,6 +244,44 @@ var builtins = map[string]*object.Builtin{
 			}
 
 			return True
+		},
+	},
+	"&&": {
+		Fn: func(args object.Object) object.Object {
+			arrayArg, ok := args.(*object.Array)
+			if !ok {
+				return newError("argument to '&&' must be ARRAY, got %s", args.Type())
+			}
+			if len(arrayArg.Elements) <= 1 {
+				return newError("number of arguments to '&&' must be more than 1, got %d", len(arrayArg.Elements))
+			}
+
+			for _, arg := range arrayArg.Elements {
+				if arg != True {
+					return False
+				}
+			}
+
+			return True
+		},
+	},
+	"||": {
+		Fn: func(args object.Object) object.Object {
+			arrayArg, ok := args.(*object.Array)
+			if !ok {
+				return newError("argument to '||' must be ARRAY, got %s", args.Type())
+			}
+			if len(arrayArg.Elements) <= 1 {
+				return newError("number of arguments to '||' must be more than 1, got %d", len(arrayArg.Elements))
+			}
+
+			for _, arg := range arrayArg.Elements {
+				if arg == True {
+					return True
+				}
+			}
+
+			return False
 		},
 	},
 	"<=": {

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -138,7 +138,7 @@ var builtins = map[string]*object.Builtin{
 			}
 
 			for i := 0; i < len(arrayArg.Elements)-1; i++ {
-				if arrayArg.Elements[i] != arrayArg.Elements[i+1] {
+				if arrayArg.Elements[i].Inspect() != arrayArg.Elements[i+1].Inspect() {
 					return False
 				}
 			}
@@ -157,7 +157,7 @@ var builtins = map[string]*object.Builtin{
 			}
 
 			for i := 0; i < len(arrayArg.Elements)-1; i++ {
-				if arrayArg.Elements[i] != arrayArg.Elements[i+1] {
+				if arrayArg.Elements[i].Inspect() != arrayArg.Elements[i+1].Inspect() {
 					return True
 				}
 			}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -15,7 +15,7 @@ var (
 	False = &object.Boolean{Value: false}
 )
 
-const identEmbedPattern = `\{\s*\w+\s*\}`
+const identEmbedPattern = `\{\s*\$\w+\s*\}`
 
 func Eval(exp ast.Expression, env *object.Environment) object.Object {
 	switch expt := exp.(type) {
@@ -524,9 +524,10 @@ func evalEmbeddedIdentifiers(strLiteral *ast.StringLiteral, env *object.Environm
 		evaluatedIdents = append(evaluatedIdents, ident)
 	}
 
+	newStrValue := strLiteral.Value
 	for i, match := range matches {
-		strLiteral.Value = strings.Replace(strLiteral.Value, match, evaluatedIdents[i].Inspect(), 1)
+		newStrValue = strings.Replace(newStrValue, match, evaluatedIdents[i].Inspect(), 1)
 	}
 
-	return &object.String{Value: strLiteral.Value}
+	return &object.String{Value: newStrValue}
 }

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -836,6 +836,40 @@ func TestArrayExpression(t *testing.T) {
 				]`,
 			expected: []any{[]any{10, 20, 30}, 3},
 		},
+		{
+			name: "embed an identifier in string",
+			input: `
+				[
+					{
+						"set": {
+							"var": "$x",
+							"val": 10
+						}
+					},
+					"{$x}: hello"
+				]`,
+			expected: []any{10, "10: hello"},
+		},
+		{
+			name: "embed identifiers in string",
+			input: `
+				[
+					{
+						"set": {
+							"var": "$x",
+							"val": 10
+						}
+					},
+					{
+						"set": {
+							"var": "$y",
+							"val": 20
+						}
+					},
+					"{$x}: hello, {$y}: world"
+				]`,
+			expected: []any{10, 20, "10: hello, 20: world"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -102,6 +102,17 @@ func TestEvalIntegerExpression(t *testing.T) {
 			expected: 2,
 		},
 		{
+			name: "modulus",
+			input: `
+				{
+					"command": {
+						"symbol": "%",
+						"args": [5, 2]
+					}
+				}`,
+			expected: 1,
+		},
+		{
 			name: "single line comment",
 			input: `
 				{
@@ -303,6 +314,50 @@ func TestEvalBooleanExpression(t *testing.T) {
 					}
 				}`,
 			expected: true,
+		},
+		{
+			name: "logical AND: return true",
+			input: `
+				{
+					"command": {
+						"symbol": "&&",
+						"args": [true, true]
+					}
+				}`,
+			expected: true,
+		},
+		{
+			name: "logical AND: return false",
+			input: `
+				{
+					"command": {
+						"symbol": "&&",
+						"args": [true, false]
+					}
+				}`,
+			expected: false,
+		},
+		{
+			name: "logical OR: return true",
+			input: `
+				{
+					"command": {
+						"symbol": "||",
+						"args": [true, false]
+					}
+				}`,
+			expected: true,
+		},
+		{
+			name: "logical OR: return false",
+			input: `
+				{
+					"command": {
+						"symbol": "||",
+						"args": [false, false]
+					}
+				}`,
+			expected: false,
 		},
 	}
 

--- a/examples/fizz_buzz.jsop.json
+++ b/examples/fizz_buzz.jsop.json
@@ -1,0 +1,114 @@
+[
+    {
+        "set": {
+            "var": "$num",
+            "val": 31
+        }
+    },
+    {
+        "loop": {
+            "for": "$i",
+            "from": 1,
+            "until": "$num",
+            "do": {
+                "if": {
+                    "cond": {
+                        "command": {
+                            "symbol": "&&",
+                            "args": [
+                                {
+                                    "command": {
+                                        "symbol": "==",
+                                        "args": [
+                                            {
+                                                "command": {
+                                                    "symbol": "%",
+                                                    "args": ["$i", 3]
+                                                }
+                                            },
+                                            0
+                                        ]
+                                    }
+                                },
+                                {
+                                    "command": {
+                                        "symbol": "==",
+                                        "args": [
+                                            {
+                                                "command": {
+                                                    "symbol": "%",
+                                                    "args": ["$i", 5]
+                                                }
+                                            },
+                                            0
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "conseq": {
+                        "command": {
+                            "symbol": "print",
+                            "args": "{$i}: FizzBuzz"
+                        }
+                    },
+                    "alt": {
+                        "if": {
+                            "cond": {
+                                "command": {
+                                    "symbol": "==",
+                                    "args": [
+                                        {
+                                            "command": {
+                                                "symbol": "%",
+                                                "args": ["$i", 3]
+                                            }
+                                        },
+                                        0
+                                    ]
+                                }
+                            },
+                            "conseq": {
+                                "command": {
+                                    "symbol": "print",
+                                    "args": "{$i}: Fizz"
+                                }
+                            },
+                            "alt": {
+                                "if": {
+                                    "cond": {
+                                        "command": {
+                                            "symbol": "==",
+                                            "args": [
+                                                {
+                                                    "command": {
+                                                        "symbol": "%",
+                                                        "args": ["$i", 5]
+                                                    }
+                                                },
+                                                0
+                                            ]
+                                        }
+                                    },
+                                    "conseq": {
+                                        "command": {
+                                            "symbol": "print",
+                                            "args": "{$i}: Buzz"
+                                        }
+                                    },
+                                    "alt": {
+                                        "command": {
+                                            "symbol": "print",
+                                            "args": "$i"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+]

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -510,6 +510,120 @@ func TestSingleProgram(t *testing.T) {
 			},
 		},
 		{
+			name: "and expression",
+			input: `
+				{
+					"command": {
+						"symbol": "&&",
+						"args": [true, false]
+					}
+				}`,
+			expected: []token.Token{
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "command"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "symbol"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "&&"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "args"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACKET, Literal: "["},
+				{Type: token.TRUE, Literal: "true"},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.FALSE, Literal: "false"},
+				{Type: token.RBRACKET, Literal: "]"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.EOF, Literal: ""},
+			},
+		},
+		{
+			name: "or expression",
+			input: `
+				{
+					"command": {
+						"symbol": "||",
+						"args": [true, false]
+					}
+				}`,
+			expected: []token.Token{
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "command"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "symbol"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "||"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "args"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACKET, Literal: "["},
+				{Type: token.TRUE, Literal: "true"},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.FALSE, Literal: "false"},
+				{Type: token.RBRACKET, Literal: "]"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.EOF, Literal: ""},
+			},
+		},
+		{
+			name: "modulus expression",
+			input: `
+				{
+					"command": {
+						"symbol": "%",
+						"args": [1, 2]
+					}
+				}`,
+			expected: []token.Token{
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "command"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACE, Literal: "{"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "symbol"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "%"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.STRING, Literal: "args"},
+				{Type: token.DOUBLE_QUOTE, Literal: "\""},
+				{Type: token.COLON, Literal: ":"},
+				{Type: token.LBRACKET, Literal: "["},
+				{Type: token.INT, Literal: "1"},
+				{Type: token.COMMA, Literal: ","},
+				{Type: token.INT, Literal: "2"},
+				{Type: token.RBRACKET, Literal: "]"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.RBRACE, Literal: "}"},
+				{Type: token.EOF, Literal: ""},
+			},
+		},
+		{
 			name: "if expression",
 			input: `
 				{

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -470,6 +470,61 @@ func TestCommand(t *testing.T) {
 			},
 		},
 		{
+			name: "modulus command",
+			input: `
+				{
+					"command": {
+						"symbol": "%",
+						"args": [1, 2]
+					}
+				}`,
+			expected: &ast.KeyValueObject{
+				Token: token.Token{Type: token.LBRACE, Literal: "{"},
+				KV: []*ast.KeyValuePair{
+					{
+						Key: &ast.StringLiteral{
+							Token: token.Token{Type: token.STRING, Literal: "command"},
+							Value: "command",
+						},
+						Value: &ast.KeyValueObject{
+							Token: token.Token{Type: token.LBRACE, Literal: "{"},
+							KV: []*ast.KeyValuePair{
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "symbol"},
+										Value: "symbol",
+									},
+									Value: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "%"},
+										Value: "%",
+									},
+								},
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "args"},
+										Value: "args",
+									},
+									Value: &ast.Array{
+										Token: token.Token{Type: token.LBRACKET, Literal: "["},
+										Elements: []ast.Expression{
+											&ast.IntegerLiteral{
+												Token: token.Token{Type: token.INT, Literal: "1"},
+												Value: 1,
+											},
+											&ast.IntegerLiteral{
+												Token: token.Token{Type: token.INT, Literal: "2"},
+												Value: 2,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "equation command",
 			input: `
 				{
@@ -514,6 +569,116 @@ func TestCommand(t *testing.T) {
 											&ast.IntegerLiteral{
 												Token: token.Token{Type: token.INT, Literal: "2"},
 												Value: 2,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "and command",
+			input: `
+				{
+					"command": {
+						"symbol": "&&",
+						"args": [true, false]
+					}
+				}`,
+			expected: &ast.KeyValueObject{
+				Token: token.Token{Type: token.LBRACE, Literal: "{"},
+				KV: []*ast.KeyValuePair{
+					{
+						Key: &ast.StringLiteral{
+							Token: token.Token{Type: token.STRING, Literal: "command"},
+							Value: "command",
+						},
+						Value: &ast.KeyValueObject{
+							Token: token.Token{Type: token.LBRACE, Literal: "{"},
+							KV: []*ast.KeyValuePair{
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "symbol"},
+										Value: "symbol",
+									},
+									Value: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "&&"},
+										Value: "&&",
+									},
+								},
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "args"},
+										Value: "args",
+									},
+									Value: &ast.Array{
+										Token: token.Token{Type: token.LBRACKET, Literal: "["},
+										Elements: []ast.Expression{
+											&ast.Boolean{
+												Token: token.Token{Type: token.TRUE, Literal: "true"},
+												Value: true,
+											},
+											&ast.Boolean{
+												Token: token.Token{Type: token.FALSE, Literal: "false"},
+												Value: false,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "or command",
+			input: `
+				{
+					"command": {
+						"symbol": "||",
+						"args": [true, false]
+					}
+				}`,
+			expected: &ast.KeyValueObject{
+				Token: token.Token{Type: token.LBRACE, Literal: "{"},
+				KV: []*ast.KeyValuePair{
+					{
+						Key: &ast.StringLiteral{
+							Token: token.Token{Type: token.STRING, Literal: "command"},
+							Value: "command",
+						},
+						Value: &ast.KeyValueObject{
+							Token: token.Token{Type: token.LBRACE, Literal: "{"},
+							KV: []*ast.KeyValuePair{
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "symbol"},
+										Value: "symbol",
+									},
+									Value: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "||"},
+										Value: "||",
+									},
+								},
+								{
+									Key: &ast.StringLiteral{
+										Token: token.Token{Type: token.STRING, Literal: "args"},
+										Value: "args",
+									},
+									Value: &ast.Array{
+										Token: token.Token{Type: token.LBRACKET, Literal: "["},
+										Elements: []ast.Expression{
+											&ast.Boolean{
+												Token: token.Token{Type: token.TRUE, Literal: "true"},
+												Value: true,
+											},
+											&ast.Boolean{
+												Token: token.Token{Type: token.FALSE, Literal: "false"},
+												Value: false,
 											},
 										},
 									},


### PR DESCRIPTION
- add test for and, or, mod command in lexer (#59)
- refactor lexer (#59)
- add test for and, or, mod command in parser (#59)
- add builtin method for and, or, mod operation (#59)
- add test for and, or, mod command in eval (#59)
- add unit test for embedded ident in string (#60)
- handle with embedded idents in string (#60)
- fix equal builtin function (#59)
- fix evalEmbeddedIdentifiers (#59)
- add examples for fizz buzz (#59)
